### PR TITLE
Linked business events are not displayed on detail page for cached post - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -15,6 +15,7 @@ WPML custom posts slug translation not working with GD (requires CPT and Event a
 WPML popular post view rating on details page all the same as main post - FIXED
 Import Export is now compatible with WPML - FIXED
 Popular post widget set to use "All" if no category selected - CHANGED
+Linked business events are not displayed on detail page for cached post - FIXED
 
 v1.4.9
 Google Analytics extra error messages added to help users debug - ADDED

--- a/geodirectory-functions/custom_functions.php
+++ b/geodirectory-functions/custom_functions.php
@@ -1515,7 +1515,7 @@ function geodir_show_detail_page_tabs()
                                 echo $related_listing;
                                 break;
                             default: {
-                                if ((isset($post->$tab_index) || !isset($post->$tab_index) && strpos($tab_index, 'gd_tab_') !== false) && !empty($detail_page_tab['tab_content'])) {
+                                if ((isset($post->$tab_index) || (!isset($post->$tab_index) && (strpos($tab_index, 'gd_tab_') !== false || $tab_index == 'link_business'))) && !empty($detail_page_tab['tab_content'])) {
                                     echo $detail_page_tab['tab_content'];
                                 }
                             }


### PR DESCRIPTION
- Linked business events are not displayed on detail page for cached post - FIXED