### PR TITLE
Popular post view widget is no longer stripping HTML in the excerpt - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,6 +1,8 @@
 v1.5.1
 Default sort by titles not translatable - FIXED
 Listings permalinks are broken if slug matches part of host or base url - FIXED
+Popular post view widget is no longer stripping HTML in the excerpt - FIXED
+
 
 v1.5.0
 Google analytic countries throws error - FIXED

--- a/geodirectory-functions/custom_functions.php
+++ b/geodirectory-functions/custom_functions.php
@@ -109,8 +109,10 @@ function geodir_max_excerpt($charlength)
         return;
     }
     $out = '';
-    $excerpt = apply_filters('the_excerpt', $post->post_content);
-    //return;
+	
+	$temp_post = $post;
+	$excerpt = get_the_excerpt();
+
     $charlength++;
     $excerpt_more = function_exists('geodirf_excerpt_more') ? geodirf_excerpt_more('') : geodir_excerpt_more('');
     if (mb_strlen($excerpt) > $charlength) {
@@ -156,6 +158,7 @@ function geodir_max_excerpt($charlength)
             $out .= $excerpt;
         }
     }
+	$post = $temp_post;
 
     return $out;
 }


### PR DESCRIPTION
- Popular post view widget is no longer stripping HTML in the excerpt - FIXED