### PR TITLE
Yoast SEO is unable to overwrite the home page meta title - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -6,6 +6,7 @@ Location switcher ajax search not working with accents chars - FIXED
 Best of widget Option added to display reviews in excerpt - ADDED
 Image gallery lightbox popup image stretches problem with some themes - FIXED
 Changed creation of url custom field from varchar 255 to text for longer urls - CHANGED
+Yoast SEO is unable to overwrite the home page meta title - FIXED
 
 v1.5.3
 If tax query has 'relation' set then it will throw WARNING in wp_list_pluck - FIXED

--- a/geodirectory_hooks_actions.php
+++ b/geodirectory_hooks_actions.php
@@ -2299,7 +2299,11 @@ function geodir_post_type_archive_title($title)
     }
 
     if ( defined( 'WPSEO_FILE' ) ) {
-        if(is_home() && is_page_geodir_home()){
+        // Force rewrite YOAST SEO home page title.
+		$wpseo_titles = get_option('wpseo_titles');
+		$forcerewritetitle = !empty($wpseo_titles) && isset($wpseo_titles['forcerewritetitle']) && !empty($wpseo_titles['forcerewritetitle']) ? true : false;
+		
+		if(is_home() && is_page_geodir_home() && !$forcerewritetitle){
             $sep = isset($sep) ? $sep : '&#8902;';
             $title = get_option('blogname') . ' ' . $sep . ' ' . get_option('blogdescription');
         }


### PR DESCRIPTION
- Yoast SEO is unable to overwrite the home page meta title - FIXED