### PR TITLE
Breadcrumb formatting issue with the neighbourhood name - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -9,7 +9,8 @@ Make ratings stars clickable on listing - ADDED
 Fix for WordFence warning on registration via GD Login - FIXED
 Textarea and html custom field can now use default value - CHANGED
 Kleo theme title not show on preview page - FIXED
-Fix ISO2 for translated country - FIXED 
+Fix ISO2 for translated country - FIXED
+Breadcrumb formatting issue with the neighbourhood name - FIXED
 
 v1.6.15
 Google Services API can conflict with newer version of the Google Service Class - UPDATED

--- a/change_log.txt
+++ b/change_log.txt
@@ -13,6 +13,7 @@ Fix ISO2 for translated country - FIXED
 Breadcrumb formatting issue with the neighbourhood name - FIXED
 On add listing page switching WPML language changes the listing type - CHANGED
 Option added in listing map widget to enable marker cluster for map - CHANGED
+Google Analytics account error breaks the site - FIXED
 
 v1.6.15
 Google Services API can conflict with newer version of the Google Service Class - UPDATED

--- a/change_log.txt
+++ b/change_log.txt
@@ -11,6 +11,7 @@ Textarea and html custom field can now use default value - CHANGED
 Kleo theme title not show on preview page - FIXED
 Fix ISO2 for translated country - FIXED
 Breadcrumb formatting issue with the neighbourhood name - FIXED
+On add listing page switching WPML language changes the listing type - CHANGED
 
 v1.6.15
 Google Services API can conflict with newer version of the Google Service Class - UPDATED

--- a/change_log.txt
+++ b/change_log.txt
@@ -14,6 +14,7 @@ Breadcrumb formatting issue with the neighbourhood name - FIXED
 On add listing page switching WPML language changes the listing type - CHANGED
 Option added in listing map widget to enable marker cluster for map - CHANGED
 Google Analytics account error breaks the site - FIXED
+Auto register custom fields for WPML translation via GD custom field translation tool - CHANGED
 
 v1.6.15
 Google Services API can conflict with newer version of the Google Service Class - UPDATED

--- a/change_log.txt
+++ b/change_log.txt
@@ -12,6 +12,7 @@ Kleo theme title not show on preview page - FIXED
 Fix ISO2 for translated country - FIXED
 Breadcrumb formatting issue with the neighbourhood name - FIXED
 On add listing page switching WPML language changes the listing type - CHANGED
+Option added in listing map widget to enable marker cluster for map - CHANGED
 
 v1.6.15
 Google Services API can conflict with newer version of the Google Service Class - UPDATED

--- a/geodirectory-admin/admin_functions.php
+++ b/geodirectory-admin/admin_functions.php
@@ -6616,7 +6616,12 @@ function geodir_gd_accounts(){
     $accounts = array();
     $useAuth = ( get_option( 'geodir_ga_auth_code' ) == '' ? false : true );
     if($useAuth){
-        $accounts = geodir_ga_get_analytics_accounts();
+        try {
+            $accounts = geodir_ga_get_analytics_accounts();
+        } catch (Exception $e) {
+            geodir_error_log( wp_sprintf( __( 'GD Google Analytics API Error(%s) : %s', 'geodirectory' ), $e->getCode(), $e->getMessage() ) );
+        }
+        
         if(is_array($accounts)){
             $accounts = array_merge(array(__('Select Account','geodirectory')),$accounts);
         }elseif(get_option('geodir_ga_account_id')){

--- a/geodirectory-functions/ajax_handler_functions.php
+++ b/geodirectory-functions/ajax_handler_functions.php
@@ -386,7 +386,11 @@ function geodir_show_ga_stats(){
     } else {
         $ga_end = '';
     }
-    geodir_getGoogleAnalytics($_REQUEST['ga_page'], $ga_start, $ga_end);
+    try {
+        geodir_getGoogleAnalytics($_REQUEST['ga_page'], $ga_start, $ga_end);
+    } catch (Exception $e) {
+        geodir_error_log( wp_sprintf( __( 'GD Google Analytics API Error(%s) : %s', 'geodirectory' ), $e->getCode(), $e->getMessage() ) );
+    }
     die;
 }
 add_action( 'wp_ajax_gdga', 'geodir_show_ga_stats' );

--- a/geodirectory-functions/custom_fields_input_functions.php
+++ b/geodirectory-functions/custom_fields_input_functions.php
@@ -39,9 +39,9 @@ function geodir_cfi_fieldset($html,$cf){
         ob_start(); // Start  buffering;
         ?>
         <h5 id="geodir_fieldset_<?php echo (int) $cf['id']; ?>" class="geodir-fieldset-row"
-            gd-fieldset="<?php echo (int) $cf['id']; ?>"><?php echo $cf['site_title']; ?>
+            gd-fieldset="<?php echo (int) $cf['id']; ?>"><?php echo __( $cf['site_title'], 'geodirectory' ); ?>
             <?php if ( $cf['desc'] != '' ) {
-                echo '<small>( ' . $cf['desc'] . ' )</small>';
+                echo '<small>( ' . __( $cf['desc'], 'geodirectory' ) . ' )</small>';
             } ?></h5>
         <?php
         $html = ob_get_clean();

--- a/geodirectory-functions/custom_functions.php
+++ b/geodirectory-functions/custom_functions.php
@@ -752,15 +752,15 @@ function geodir_related_posts_display( $request ) {
 		$character_count     = ( isset( $request['character_count'] ) && ! empty( $request['character_count'] ) ) ? $request['character_count'] : '';
 
 		global $wpdb, $post, $gd_session, $related_nearest, $related_parent_lat, $related_parent_lon;
-		$related_parent_lat   = $post->post_latitude;
-		$related_parent_lon   = $post->post_longitude;
+		$related_parent_lat   = !empty($post->post_latitude) ? $post->post_latitude : '';
+		$related_parent_lon   = !empty($post->post_longitude) ? $post->post_longitude : '';
 		$arr_detail_page_tabs = geodir_detail_page_tabs_list();
 
 		$related_listing_array = array();
 		if ( get_option( 'geodir_add_related_listing_posttypes' ) ) {
 			$related_listing_array = get_option( 'geodir_add_related_listing_posttypes' );
 		}
-		if ( in_array( $post->post_type, $related_listing_array ) ) {
+		if ( isset($post->post_type) && in_array( $post->post_type, $related_listing_array ) ) {
 			$arr_detail_page_tabs['related_listing']['is_display'] = true;
 		}
 

--- a/geodirectory-functions/general_functions.php
+++ b/geodirectory-functions/general_functions.php
@@ -4181,6 +4181,7 @@ function geodirectory_load_db_language() {
 	 * Filter the language string from database to translate via po editor
 	 *
 	 * @since 1.4.2
+	 * @since 1.6.16 Register the string for WPML translation.
 	 *
 	 * @param array $contents_strings Array of strings.
 	 */
@@ -4209,6 +4210,7 @@ function geodirectory_load_db_language() {
 		foreach ( $contents_strings as $string ) {
 			if ( is_scalar( $string ) && $string != '' ) {
 				$string = str_replace( "'", "\'", $string );
+				geodir_wpml_register_string( $string );
 				$contents .= PHP_EOL . "__('" . $string . "', 'geodirectory');";
 			}
 		}
@@ -5276,3 +5278,33 @@ function geodir_remove_hentry( $class ) {
 }
 
 add_filter( 'post_class', 'geodir_remove_hentry' );
+
+/**
+ * Registers a individual text string for WPML translation.
+ *
+ * @since 1.6.16 Details page add locations to the term links.
+ * @package GeoDirectory
+ *
+ * @param string $string The string that needs to be translated.
+ * @param string $domain The plugin domain. Default geodirectory.
+ * @param string $name The name of the string which helps to know what's being translated.
+ */
+function geodir_wpml_register_string( $string, $domain = 'geodirectory', $name = '' ) {
+    do_action( 'wpml_register_single_string', $domain, $name, $string );
+}
+
+/**
+ * Retrieves an individual WPML text string translation.
+ *
+ * @since 1.6.16 Details page add locations to the term links.
+ * @package GeoDirectory
+ *
+ * @param string $string The string that needs to be translated.
+ * @param string $domain The plugin domain. Default geodirectory.
+ * @param string $name The name of the string which helps to know what's being translated.
+ * @param string $language_code Return the translation in this language. Default is NULL which returns the current language.
+ * @return string The translated string.
+ */
+function geodir_wpml_translate_string( $string, $domain = 'geodirectory', $name = '', $language_code = NULL ) {
+    return apply_filters( 'wpml_translate_single_string', $string, $domain, $name, $language_code );
+}

--- a/geodirectory-functions/general_functions.php
+++ b/geodirectory-functions/general_functions.php
@@ -1234,6 +1234,7 @@ function geodir_wpml_post_type_archive_link($link, $post_type){
  *
  * @since   1.0.0
  * @since   1.5.7 Changes for the neighbourhood system improvement.
+ * @since   1.6.16 Fix: Breadcrumb formatting issue with the neighbourhood name.
  * @package GeoDirectory
  * @global object $wp_query   WordPress Query object.
  * @global object $post       The current post object.
@@ -1372,6 +1373,7 @@ function geodir_breadcrumb() {
 						$location_term_actual_country = '';
 						$location_term_actual_region  = '';
 						$location_term_actual_city    = '';
+						$location_term_actual_neighbourhood = '';
 						if ( $geodir_get_locations ) {
 							if ( $key == 'gd_country' ) {
 								$location_term_actual_country = get_actual_location_name( 'country', $location_term, true );
@@ -1379,6 +1381,8 @@ function geodir_breadcrumb() {
 								$location_term_actual_region = get_actual_location_name( 'region', $location_term, true );
 							} else if ( $key == 'gd_city' ) {
 								$location_term_actual_city = get_actual_location_name( 'city', $location_term, true );
+							} else if ( $key == 'gd_neighbourhood' ) {
+								$location_term_actual_neighbourhood = get_actual_location_name( 'neighbourhood', $location_term, true );
 							}
 						} else {
 							$location_info = geodir_get_location();
@@ -1401,7 +1405,7 @@ function geodir_breadcrumb() {
 						} else if ( $is_location_last && $key == 'gd_city' && empty( $location_terms['gd_neighbourhood'] ) ) {
 							$breadcrumb .= $location_term_actual_city != '' ? $separator . $location_term_actual_city : $separator . $gd_location_link_text;
 						} else if ( $is_location_last && $key == 'gd_neighbourhood' ) {
-							$breadcrumb .= $separator . $gd_location_link_text;
+							$breadcrumb .= $location_term_actual_neighbourhood != '' ? $separator . $location_term_actual_neighbourhood : $separator . $gd_location_link_text;
 						} else {
 							if ( get_option( 'permalink_structure' ) != '' ) {
 								$location_link .= $location_term . '/';
@@ -1415,6 +1419,8 @@ function geodir_breadcrumb() {
 								$gd_location_link_text = $location_term_actual_region;
 							} else if ( $key == 'gd_city' && $location_term_actual_city != '' ) {
 								$gd_location_link_text = $location_term_actual_city;
+							} else if ( $key == 'gd_neighbourhood' && $location_term_actual_neighbourhood != '' ) {
+								$gd_location_link_text = $location_term_actual_neighbourhood;
 							}
 
 							/*

--- a/geodirectory-functions/location_functions.php
+++ b/geodirectory-functions/location_functions.php
@@ -198,6 +198,7 @@ function geodir_location_form_submit()
  * Adds new location using location info.
  *
  * @since 1.0.0
+ * @since 1.6.16 Fix country translation.
  * @package GeoDirectory
  * @global object $wpdb WordPress Database object.
  * @param array $location_info {
@@ -217,17 +218,16 @@ function geodir_add_new_location($location_info = array())
     global $wpdb;
 
     if (!empty($location_info)) {
-
         $location_city = ($location_info['city'] != '') ? $location_info['city'] : 'all';
         $location_region = ($location_info['region'] != '') ? $location_info['region'] : 'all';
-        $location_country = ($location_info['country'] != '') ? $location_info['country'] : 'all';
+        $location_country = ($location_info['country'] != '') ? geodir_get_normal_country($location_info['country']) : 'all';
         $location_lat = ($location_info['geo_lat'] != '') ? $location_info['geo_lat'] : '';
         $location_lng = ($location_info['geo_lng'] != '') ? $location_info['geo_lng'] : '';
         $is_default = isset($location_info['is_default']) ? $location_info['is_default'] : '';
         $country_slug = create_location_slug(__($location_country, 'geodirectory'));
         $region_slug = create_location_slug($location_region);
         $city_slug = create_location_slug($location_city);
-
+        
         /**
          * Filter add new location data.
          *
@@ -244,7 +244,6 @@ function geodir_add_new_location($location_info = array())
             'city_longitude' => $location_lng,
             'is_default' => $is_default
         ));
-
 
         /* // Not allowed to create country in DB : 2016-12-09
         if ($geodir_location->country) {
@@ -542,7 +541,7 @@ function geodir_get_country_iso2($country) {
  * @since 1.6.16
  * @package GeoDirectory
  * @param string $country The country name or iso2.
- * @param bool $iso2 If true it searchs by country iso2.
+ * @param bool $iso2 If true it searches by country iso2.
  * @return string|null Country ISO2 code.
  */
 function geodir_get_country_by_name($country, $iso2 = false) {

--- a/geodirectory-widgets/listing_map_widget.php
+++ b/geodirectory-widgets/listing_map_widget.php
@@ -215,6 +215,8 @@ class geodir_map_listingpage extends WP_Widget
             $map_args['maxZoom'] = 21;
             $map_args['autozoom'] = $autozoom;
             $map_args['bubble_size'] = 'small';
+            
+            $map_args['enable_marker_cluster'] = defined('GDCLUSTER_VERSION') && !empty($instance['marker_cluster']) ? true : false;
 
             echo $before_widget;
             geodir_draw_map($map_args);
@@ -234,8 +236,7 @@ class geodir_map_listingpage extends WP_Widget
 	 *
 	 * @return array Updated safe values to be saved.
 	 */
-    public function update($new_instance, $old_instance)
-    {
+    public function update($new_instance, $old_instance) {
         //save the widget
         $instance = $old_instance;
         $instance['width'] = strip_tags($new_instance['width']);
@@ -246,6 +247,7 @@ class geodir_map_listingpage extends WP_Widget
         $instance['sticky'] = isset($new_instance['sticky']) ? $new_instance['sticky'] : '';
         $instance['scrollwheel'] = isset($new_instance['scrollwheel']) ? ($new_instance['scrollwheel']) : '';
         $instance['showall'] = isset($new_instance['showall']) ? ($new_instance['showall']) : '';
+        $instance['marker_cluster'] = defined('GDCLUSTER_VERSION') && !empty($new_instance['marker_cluster']) ? 1 : '';
 
         return $instance;
     }
@@ -258,10 +260,10 @@ class geodir_map_listingpage extends WP_Widget
 	 *
 	 * @param array $instance Previously saved values from database.
 	 */
-    public function form($instance)
-    {
-        //widgetform in backend
-        $instance = wp_parse_args((array)$instance, array('width' => '', 'heigh' => '', 'maptype' => '', 'zoom' => '', 'autozoom' => '', 'sticky' => '', 'scrollwheel' => '0', 'showall' => '0'));
+    public function form($instance) {
+        // widget form in backend
+        $instance = wp_parse_args((array)$instance, array('width' => '', 'heigh' => '', 'maptype' => '', 'zoom' => '', 'autozoom' => '', 'sticky' => '', 'scrollwheel' => '0', 'showall' => '0', 'marker_cluster' => '0'));
+        
         $width = strip_tags($instance['width']);
         $heigh = strip_tags($instance['heigh']);
         $maptype = strip_tags($instance['maptype']);
@@ -270,6 +272,7 @@ class geodir_map_listingpage extends WP_Widget
         $sticky = strip_tags($instance['sticky']);
         $scrollwheel = strip_tags($instance['scrollwheel']);
         $showall = strip_tags($instance['showall']);
+        $marker_cluster = (int)$instance['marker_cluster'];
         ?>
         <p>
             <label
@@ -341,33 +344,37 @@ class geodir_map_listingpage extends WP_Widget
 
         <p>
             <label
-                for="<?php echo $this->get_field_id('autozoom'); ?>"><?php _e('Map Auto Zoom ?', 'geodirectory'); ?>
-                :
+                for="<?php echo $this->get_field_id('autozoom'); ?>">
                 <input type="checkbox" class="checkbox" id="<?php echo $this->get_field_id('autozoom'); ?>"
                        name="<?php echo $this->get_field_name('autozoom'); ?>"<?php if ($autozoom) {
                     echo 'checked="checked"';
-                } ?> /></label>
+                } ?> /> <?php _e('Map Auto Zoom ?', 'geodirectory'); ?></label>
         </p>
 
         <p>
             <label
-                for="<?php echo $this->get_field_id('sticky'); ?>"><?php _e('Map Sticky(should stick to the right of screen) ?', 'geodirectory'); ?>
-                :
+                for="<?php echo $this->get_field_id('sticky'); ?>">
                 <input type="checkbox" class="checkbox" id="<?php echo $this->get_field_id('sticky'); ?>"
                        name="<?php echo $this->get_field_name('sticky'); ?>"<?php if ($sticky) {
                     echo 'checked="checked"';
-                } ?> /> </label>
+                } ?> /> <?php _e('Map Sticky(should stick to the right of screen) ?', 'geodirectory'); ?>
+            </label>
         </p>
 
         <p>
             <label
-                for="<?php echo $this->get_field_id('scrollwheel'); ?>"><?php _e('Enable mouse scroll zoom ?', 'geodirectory'); ?>
-                :
+                for="<?php echo $this->get_field_id('scrollwheel'); ?>">
                 <input id="<?php echo $this->get_field_id('scrollwheel'); ?>"
                        name="<?php echo $this->get_field_name('scrollwheel'); ?>" type="checkbox" value="1"
-                       <?php if ($scrollwheel){ ?>checked="checked" <?php } ?> />
+                       <?php if ($scrollwheel){ ?>checked="checked" <?php } ?> /> <?php _e('Enable mouse scroll zoom ?', 'geodirectory'); ?>
             </label>
         </p>
+        <?php if (defined('GDCLUSTER_VERSION')) { ?>
+        <p>
+            <label for="<?php echo $this->get_field_id('marker_cluster'); ?>"><input id="<?php echo $this->get_field_id('marker_cluster'); ?>" name="<?php echo $this->get_field_name('marker_cluster'); ?>" type="checkbox" value="1" <?php checked($marker_cluster, 1); ?> /> <?php _e('Enable marker cluster?', 'geodirectory'); ?>
+            </label>
+        </p>
+        <?php } ?>
 
         <!-- <p>
       <label for="<?php echo $this->get_field_id('showall'); ?>"><?php _e('Show all listings on map? (not just page list)', 'geodirectory'); ?>:


### PR DESCRIPTION
- Breadcrumb formatting issue with the neighbourhood name - FIXED
- On add listing page switching WPML language changes the listing type - CHANGED
- Option added in listing map widget to enable marker cluster for map - CHANGED
- Google Analytics account error breaks the site - FIXED
- Auto register custom fields for WPML translation via GD custom field translation tool - CHANGED