### PR TITLE
With WPML the location terms added twice when CPT slug is translated - FIXED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,6 @@
 v1.6.18
 Custom field should display label instead of value if set in option values - FIXED
+With WPML the location terms added twice when CPT slug is translated - FIXED
 
 v1.6.17
 Changes for batch WPML duplicates feature - CHANGED

--- a/change_log.txt
+++ b/change_log.txt
@@ -2,6 +2,7 @@ v1.6.18
 Custom field should display label instead of value if set in option values - FIXED
 With WPML the location terms added twice when CPT slug is translated - FIXED
 gd_listing_map shortcode not working for CPT other then "gd_place" - FIXED
+GD Booster causes problem when used http in urls on SSL enabled site - FIXED
 
 v1.6.17
 Changes for batch WPML duplicates feature - CHANGED

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,6 +1,7 @@
 v1.6.18
 Custom field should display label instead of value if set in option values - FIXED
 With WPML the location terms added twice when CPT slug is translated - FIXED
+gd_listing_map shortcode not working for CPT other then "gd_place" - FIXED
 
 v1.6.17
 Changes for batch WPML duplicates feature - CHANGED

--- a/geodirectory-functions/general_functions.php
+++ b/geodirectory-functions/general_functions.php
@@ -22,18 +22,20 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Return the plugin folder url WITHOUT TRAILING SLASH.
  *
  * @since   1.0.0
+ * @since   1.6.18 Fix: GD Booster causes problem when used http in urls on SSL enabled site.
  * @package GeoDirectory
  * @return string example url eg: http://wpgeo.directory/wp-content/plugins/geodirectory
  */
 function geodir_plugin_url() {
-
+	return plugins_url( '', dirname( __FILE__ ) );
+	/*
 	if ( is_ssl() ) :
 		return str_replace( 'http://', 'https://', WP_PLUGIN_URL ) . "/" . plugin_basename( dirname( dirname( __FILE__ ) ) );
 	else :
 		return WP_PLUGIN_URL . "/" . plugin_basename( dirname( dirname( __FILE__ ) ) );
 	endif;
+	*/
 }
-
 
 /**
  * Return the plugin path.

--- a/geodirectory_shortcodes.php
+++ b/geodirectory_shortcodes.php
@@ -239,6 +239,7 @@ add_shortcode('gd_listing_map', 'geodir_sc_listing_map');
  * @since 1.0.0
  * @since 1.5.2 Added TERRAIN for $maptype attribute.
  * @since 1.6.16 CHANGED: New parameters post_type, category & event_type added.
+ * @since 1.6.18 FIXED: For CPT other then "gd_place" not working.
  * @package GeoDirectory
  * @global object $post The current post object.
  * @param array $atts {
@@ -322,6 +323,7 @@ function geodir_sc_listing_map($atts) {
             'posts_per_page' => 1000000, //@todo kiran why was this added? 
             'is_geodir_loop' => true,
             'gd_location'    => false,
+            'post_type'      => $params['post_type'],
         );
 
         if ( ! empty( $params['category'] ) && isset( $params['category'][0] ) && (int) $params['category'][0] != 0 ) {


### PR DESCRIPTION
- With WPML the location terms added twice when CPT slug is translated - FIXED
- gd_listing_map shortcode not working for CPT other then "gd_place" - FIXED